### PR TITLE
Exclude node-html from dojo amd processing

### DIFF
--- a/package.js
+++ b/package.js
@@ -2,6 +2,9 @@ var miniExcludes = {
 		"put-selector/README.md": 1,
 		"put-selector/package": 1
 	},
+	amdExcludes = {
+		"put-selector/node-html": 1
+	},
 	isTestRe = /\/test\//;
 
 var profile = {
@@ -15,7 +18,7 @@ var profile = {
 		},
 
 		amd: function(filename, mid){
-			return /\.js$/.test(filename);
+			return /\.js$/.test(filename) && !(mid in amdExcludes);
 		}
 	}
 };


### PR DESCRIPTION
Getting this error in the dojo build process:

error(307) Failed to evaluate module tagged as pure AMD (fell back to processing with regular expressions). module: put-selector/node-html; error: ReferenceError: module is not defined
