### PR TITLE
Error running sample in node.js

### DIFF
--- a/put.js
+++ b/put.js
@@ -14,8 +14,12 @@ define([], forDocument = function(doc, newFragmentFasterHeuristic){
 	fragmentFasterHeuristic = newFragmentFasterHeuristic || fragmentFasterHeuristic;
 	var selectorParse = /(?:\s*([-+ ,<>]))?\s*(\.|!\.?|#)?([-\w%$]+)?(?:\[([^\]=]+)=?['"]?([^\]'"]*)['"]?\])?/g,
 		undefined,
-		doc = doc || document,
-		ieCreateElement = typeof doc.createElement == "object"; // telltale sign of the old IE behavior with createElement that does not support later addition of name 
+		ieCreateElement;
+	if(typeof window != "undefined"){
+		doc = doc || document;
+	}
+	ieCreateElement = doc && typeof doc.createElement == "object"; // telltale sign of the old IE behavior with createElement that does not support later addition of name 
+
 	function insertTextNode(element, text){
 		element.appendChild(doc.createTextNode(text));
 	}


### PR DESCRIPTION
Could not run the sample in node.js 0.9.4-pre because it refers to an
unexisting "document" variable.
The workaround was easy. It runs ok now.

Steps to reproduce:

1) checkout and compile node.js
2) recreate the sample in put-selector's readme file
3) Run it. The output should be something like this:

PS C:\sample> node .\testfile.js

C:\sample\node_modules\put-selector\put.js:17
                doc = doc || document,
                             ^
ReferenceError: document is not defined
    at forDocument (C:\sample\node_modules\put-selector\put.js:17:16)
    at module.exports (C:\sample\node_modules\put-selector\node-html.js:179:28)
    at C:\sample\node_modules\put-selector\put.js:195:25
    at C:\sample\node_modules\put-selector\put.js:3:1
    at Object.<anonymous> (C:\sample\node_modules\put-selector\put.js:192:3)
    at Module._compile (module.js:454:26)
    at Object.Module._extensions..js (module.js:472:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:362:17)
