### PR TITLE
package.js fixes, primarily for node-html

### DIFF
--- a/package.js
+++ b/package.js
@@ -7,6 +7,7 @@ var miniExcludes = {
 	copyOnly = {
 		"put-selector/node-html": 1
 	},
+	isJsRe = /\.js$/,
 	isTestRe = /\/test\//;
 
 var profile = {
@@ -20,7 +21,7 @@ var profile = {
 		},
 
 		amd: function(filename, mid){
-			return /\.js$/.test(filename) && !(mid in amdExcludes);
+			return isJsRe.test(filename) && !(mid in amdExcludes);
 		},
 
 		copyOnly: function(filename, mid){


### PR DESCRIPTION
This pull request includes 2 commits.

The primary concern is addressed in dac833d, which tags the `node-html` module as `copyOnly` instead of marking it as not AMD.  Given that this is a module intended for use with node, it's kind of superfluous for the build to process it anyway.  This resolves two things:
- The build will no longer improperly wrap this module with AMD boilerplate with dojo, dijit, and dojox
- The build will no longer complain about this module if `dijit` or `dojox` are not included as packages (since the module will no longer be processed and improperly wrapped)

The other commit moves the regular expression for the `amd` resource tag into a variable, matching how the `test` resource tag works.
