### PR TITLE
Fix expose AMD

### DIFF
--- a/put.js
+++ b/put.js
@@ -213,7 +213,7 @@ define([], forDocument = function(doc, newFragmentFasterHeuristic){
 });
 })(function(id, deps, factory){
 	factory = factory || deps;
-	if(typeof define != "undefined"){
+	if(typeof define === "function" && define.amd){
 		// AMD loader
 		define([], function(){
 			return factory();


### PR DESCRIPTION
According to [AMD API](https://github.com/amdjs/amdjs-api/wiki/AMD), you sould [verify the existence of the `amd` property](https://github.com/amdjs/amdjs-api/wiki/AMD#defineamd-property-) on the `define` function.
