### PR TITLE
Allow non-ASCII Unicode in idents, per CSS 2.1

### DIFF
--- a/put.js
+++ b/put.js
@@ -12,7 +12,7 @@ define([], forDocument = function(doc, newFragmentFasterHeuristic){
 	//		To create a simple div with a class name of "foo":
 	//		|	put("div.foo");
 	fragmentFasterHeuristic = newFragmentFasterHeuristic || fragmentFasterHeuristic;
-	var selectorParse = /(?:\s*([-+ ,<>]))?\s*(\.|!\.?|#)?([-\w%$|]+)?(?:\[([^\]=]+)=?['"]?([^\]'"]*)['"]?\])?/g,
+	var selectorParse = /(?:\s*([-+ ,<>]))?\s*(\.|!\.?|#)?([-\w\u00A0-\uFFFF%$|]+)?(?:\[([^\]=]+)=?['"]?([^\]'"]*)['"]?\])?/g,
 		undefined, namespaceIndex, namespaces = false,
 		doc = doc || document,
 		ieCreateElement = typeof doc.createElement == "object"; // telltale sign of the old IE behavior with createElement that does not support later addition of name 

--- a/test/put.js
+++ b/test/put.js
@@ -93,4 +93,7 @@ var svg = put(document.body, "svg|svg#svg-test");
 put(svg, "!");
 console.assert(document.getElementById("svg-test") == null);
 
+var unicode = put("div.unicode-你好");
+console.assert(unicode.className === "unicode-你好");
+
 put(body, "div", {innerHTML: "finished tests, check console for errors"});


### PR DESCRIPTION
Fixes #6
